### PR TITLE
Make REDIS_STOP_WRITES_ON_BGSAVE_ERROR a string

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ REDIS_SAVE_FREQUENCIES:
   - {seconds: 900, changes: 1}
   - {seconds: 300, changes: 10}
   - {seconds: 60, changes: 10000}
-REDIS_STOP_WRITES_ON_BGSAVE_ERROR: yes
+REDIS_STOP_WRITES_ON_BGSAVE_ERROR: "yes"
 REDIS_DB_FILENAME: "dump.rdb"
 REDIS_DB_DIRECTORY: /var/lib/redis/
 REDIS_MASTER_PASSWORD: ""


### PR DESCRIPTION
Fixes:
```
redis_1              | 
redis_1              | *** FATAL CONFIG FILE ERROR ***
redis_1              | Reading the configuration file, at line 159
redis_1              | >>> 'stop-writes-on-bgsave-error True'
redis_1              | argument must be 'yes' or 'no'
ansible_redis_1 exited with code 1
```