### PR TITLE
Prevent ansible's boolean coercion from filling in config values wrong

### DIFF
--- a/templates/redis.conf
+++ b/templates/redis.conf
@@ -156,7 +156,7 @@ save {{ checkpoint.seconds }} {{ checkpoint.changes }}
 # and persistence, you may want to disable this feature so that Redis will
 # continue to work as usual even if there are problems with disk,
 # permissions, and so forth.
-stop-writes-on-bgsave-error {{ REDIS_STOP_WRITES_ON_BGSAVE_ERROR }}
+stop-writes-on-bgsave-error {% if REDIS_STOP_WRITES_ON_BGSAVE_ERROR %}yes{% else %}no{% endif %}
 
 # Compress string objects using LZF when dump .rdb databases?
 # For default that's set to 'yes' as it's almost always a win.
@@ -502,7 +502,7 @@ maxclients {{ REDIS_MAX_CLIENTS }}
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly {{ REDIS_AOF }}
+appendonly {% if REDIS_AOF %}yes{% else %}no{% endif %}
 
 # The name of the append only file (default: "appendonly.aof")
 


### PR DESCRIPTION
If variables are provided as yes/no, Ansible will coerce them into a True/False value, which when put in the redis config fails because it doesn't recognize True as equal to "yes". 